### PR TITLE
disallow detach user from project if admin

### DIFF
--- a/virtual_labs/usecases/project/detach_user_from_project.py
+++ b/virtual_labs/usecases/project/detach_user_from_project.py
@@ -14,12 +14,14 @@ from virtual_labs.core.exceptions.api_error import VliError, VliErrorCode
 from virtual_labs.core.exceptions.generic_exceptions import ForbiddenOperation
 from virtual_labs.core.response.api_response import VliResponse
 from virtual_labs.infrastructure.kc.models import AuthUser
+from virtual_labs.repositories.group_repo import GroupQueryRepository
 from virtual_labs.repositories.project_repo import (
     ProjectQueryRepository,
 )
 from virtual_labs.repositories.user_repo import (
     UserMutationRepository,
 )
+from virtual_labs.shared.utils.uniq_list import uniq_list
 
 
 async def detach_user_from_project(
@@ -31,14 +33,17 @@ async def detach_user_from_project(
 ) -> Response | VliError:
     pqr = ProjectQueryRepository(session)
     umr = UserMutationRepository()
+    gqr = GroupQueryRepository()
 
     try:
-        project, _ = pqr.retrieve_one_project_strict(
+        project, vl = pqr.retrieve_one_project_strict(
             virtual_lab_id=virtual_lab_id,
             project_id=project_id,
         )
+        users = gqr.retrieve_group_users(group_id=str(vl.admin_group_id))
+        users_list = uniq_list([u.id for u in users])
 
-        if user_id == project.owner_id:
+        if (user_id == project.owner_id) or (user_id in users_list):
             raise ForbiddenOperation
 
         umr.detach_user_from_group(


### PR DESCRIPTION
if the user is a VL admin or a project owner then other admins can not detach it from the project