### PR TITLE
221 // Add users to get lab by id route

### DIFF
--- a/virtual_labs/domain/labs.py
+++ b/virtual_labs/domain/labs.py
@@ -124,8 +124,16 @@ class VirtualLabUser(BaseModel):
     user: UserRepresentation
 
 
+class VirtualLabWithUsers(VirtualLabDomainVerbose):
+    users: list[UserWithInviteStatus]
+
+
 class Lab(BaseModel):
     virtual_lab: VirtualLabDomain
+
+
+class LabByIdOut(BaseModel):
+    virtual_lab: VirtualLabWithUsers
 
 
 class LabVerbose(BaseModel):

--- a/virtual_labs/routes/labs.py
+++ b/virtual_labs/routes/labs.py
@@ -13,8 +13,8 @@ from virtual_labs.domain.labs import (
     AddUserToVirtualLab,
     InviteSent,
     Lab,
+    LabByIdOut,
     LabResponse,
-    LabVerbose,
     SearchLabResponse,
     VirtualLabCreate,
     VirtualLabDomain,
@@ -85,7 +85,7 @@ async def search_virtual_lab_by_name(
 
 @router.get(
     "/{virtual_lab_id}",
-    response_model=LabResponse[LabVerbose],
+    response_model=LabResponse[LabByIdOut],
     summary="Get non deleted virtual lab by id",
 )
 @verify_vlab_read
@@ -93,13 +93,11 @@ async def get_virtual_lab(
     virtual_lab_id: UUID4,
     session: AsyncSession = Depends(default_session_factory),
     auth: tuple[AuthUser, str] = Depends(verify_jwt),
-) -> LabResponse[LabVerbose]:
-    lab_response = LabVerbose(
-        virtual_lab=await usecases.get_virtual_lab(
-            session, virtual_lab_id, user_id=get_user_id_from_auth(auth)
-        )
+) -> LabResponse[LabByIdOut]:
+    lab_response = await usecases.get_virtual_lab(
+        session, virtual_lab_id, user_id=get_user_id_from_auth(auth)
     )
-    return LabResponse[LabVerbose](
+    return LabResponse[LabByIdOut](
         message="Virtual lab resource for id {}".format(virtual_lab_id),
         data=lab_response,
     )

--- a/virtual_labs/tests/test_get_lab.py
+++ b/virtual_labs/tests/test_get_lab.py
@@ -60,3 +60,6 @@ async def test_update_lab(
     assert len(lab["projects"]) == 1
     assert lab["projects"][0]["id"] == project_id
     assert lab["projects"][0]["starred"] is False
+    assert len(lab["users"]) == 1
+    assert lab["users"][0]["username"] == "test"
+    assert lab["users"][0]["invite_accepted"] is True

--- a/virtual_labs/tests/test_invite_user_to_lab.py
+++ b/virtual_labs/tests/test_invite_user_to_lab.py
@@ -48,7 +48,7 @@ def assert_invite_response(response: Response) -> None:
 def assert_right_users_in_lab(response: Response) -> None:
     assert response.status_code == 200
     lab_users_response_data = response.json()
-    lab_users = lab_users_response_data["data"]["users"]
+    lab_users = lab_users_response_data["data"]["virtual_lab"]["users"]
     assert len(lab_users) == 2
     for user in lab_users:
         if user["username"] == "test":
@@ -72,9 +72,7 @@ async def test_invite_user_to_lab(
     )
     assert_invite_response(invite_response)
 
-    lab_users_response = await client.get(
-        f"/virtual-labs/{lab_id}/users", headers=headers
-    )
+    lab_users_response = await client.get(f"/virtual-labs/{lab_id}", headers=headers)
     assert_right_users_in_lab(lab_users_response)
 
 


### PR DESCRIPTION
Adds `users` field to the virtual lab response returned in the get virtual lab by id endpoint as requested by @kplatis [on slack thread](https://bluebrainproject.slack.com/archives/C06MB0HQ7DE/p1712316809655129):


![Screenshot from 2024-04-08 15-17-05](https://github.com/BlueBrain/virtual-lab-api/assets/11242410/a5ce383e-48b7-4843-9b40-bbdc06d42849)

