### PR TITLE
When user re-accepts invite the response should contain correct lab and project ids

### DIFF
--- a/virtual_labs/infrastructure/settings.py
+++ b/virtual_labs/infrastructure/settings.py
@@ -50,9 +50,7 @@ class Settings(BaseSettings):
 
     INVITE_JWT_SECRET: str = "TEST_JWT_SECRET"
     INVITE_EXPIRES_IN_DAYS: int = 7
-    INVITE_LINK_BASE: str = (
-        DEPLOYMENT_NAMESPACE + "mmb-beta"
-    )  # TODO: This might need to be changed
+    INVITE_LINK_BASE: str = "http://localhost:3000/api"
 
     @field_validator("DATABASE_URI", mode="before")
     @classmethod

--- a/virtual_labs/usecases/invites/invitation_handler.py
+++ b/virtual_labs/usecases/invites/invitation_handler.py
@@ -59,7 +59,7 @@ async def invitation_handler(
                     data={
                         "origin": origin,
                         "invite_id": invite_id,
-                        "virtual_lab_id": virtual_lab_id,
+                        "virtual_lab_id": vlab_invite.virtual_lab_id,
                         "project_id": project_id,
                         "status": "already_accepted",
                     },
@@ -98,6 +98,9 @@ async def invitation_handler(
             project_invite = await invite_query_repo.get_project_invite_by_id(
                 invite_id=UUID(invite_id)
             )
+            project, _ = await project_query_repo.retrieve_one_project_by_id(
+                project_id=UUID(str(project_invite.project_id))
+            )
             if project_invite.accepted:
                 return VliResponse.new(
                     message="Invite for project: {}/{} already accepted".format(
@@ -107,8 +110,8 @@ async def invitation_handler(
                     data={
                         "origin": origin,
                         "invite_id": invite_id,
-                        "virtual_lab_id": virtual_lab_id,
-                        "project_id": project_id,
+                        "virtual_lab_id": project.virtual_lab_id,
+                        "project_id": project.id,
                         "status": "already_accepted",
                     },
                 )
@@ -120,10 +123,6 @@ async def invitation_handler(
                 email=str(project_invite.user_email)
             )
             assert user is not None
-
-            project, _ = await project_query_repo.retrieve_one_project_by_id(
-                project_id=UUID(str(project_invite.project_id))
-            )
 
             group_id = (
                 project.admin_group_id

--- a/virtual_labs/usecases/labs/search_virtual_labs.py
+++ b/virtual_labs/usecases/labs/search_virtual_labs.py
@@ -18,5 +18,4 @@ async def search_virtual_labs_by_name(
             db, term, group_ids
         )
     ]
-    # TODO: Filter labs for user
     return SearchLabResponse(virtual_labs=matching_labs)


### PR DESCRIPTION
The issue was that the `virtual_lab_id` and `project_id` were None