### PR TITLE
Enable accessing keycloak UI locally

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,15 @@ Access token:
 <access_token>
 ```
 
+# Accessing local (or test) keycloak UI
+
+Add keycloak as host for address 127.0.0.1 in /etc/host file
+```bash
+echo "127.0.0.1 keycloak" | sudo tee -a /etc/hosts # This adds a line "127.0.0.1 keycloak" to /etc/hosts 
+```
+
+Now navigating to http://localhost:9090 or http://keycloak:9090 should load the keycloak web interface
+
 # Generating db migrations
 
 The version numbers are stored in alembic/versions. Alembic can be used to autogenerate migration scripts based on schema changes like so:

--- a/dev-init.sh
+++ b/dev-init.sh
@@ -24,7 +24,7 @@ curl -XPUT \
   "http://localhost:8080/v1/realms/obp-realm" \
   -d '{
         "name":"obp-realm",
-        "openIdConfig":"http://keycloak:8080/realms/obp-realm/.well-known/openid-configuration"
+        "openIdConfig":"http://keycloak:9090/realms/obp-realm/.well-known/openid-configuration"
       }'
 
 echo "Initialize nexus"

--- a/env-prep/docker-compose-dev.yml
+++ b/env-prep/docker-compose-dev.yml
@@ -46,12 +46,13 @@ services:
       - keycloak-db
     command: 
       - start-dev
+      - --http-port=9090
       - --hostname=keycloak
-      - --hostname-port=8080
+      - --hostname-port=9090
       - --hostname-strict-backchannel=true
       - --import-realm
     ports:
-      - "9090:8080"
+      - "9090:9090"
     networks:
       - ls
     volumes:


### PR DESCRIPTION
Right now accessing kc ui locally by going to http://keycloak:8080 or http://localhost:8080 does not work. This makes local testing a bit difficult. The PR fixes this issue.