### PR TITLE
Lab/project description should not be added to keycloak group due to char limits

### DIFF
--- a/virtual_labs/repositories/group_repo.py
+++ b/virtual_labs/repositories/group_repo.py
@@ -65,12 +65,7 @@ class GroupMutationRepository:
         """
         try:
             group_id = self.Kc.create_group(
-                {
-                    "name": "vlab/{}/{}".format(vl_id, role.value),
-                    "attributes": {
-                        "_name": [vl_name],
-                    },
-                }
+                {"name": "vlab/{}/{}".format(vl_id, role.value)}
             )
 
             return cast(
@@ -101,13 +96,7 @@ class GroupMutationRepository:
         proj/virtual_lab_id/project_id/role
         """
         group_id = self.Kc.create_group(
-            {
-                "name": "proj/{}/{}/{}".format(virtual_lab_id, project_id, role.value),
-                "attributes": {
-                    "_name": [payload.name],
-                    "_description": [payload.description],
-                },
-            },
+            {"name": "proj/{}/{}/{}".format(virtual_lab_id, project_id, role.value)},
         )
 
         return cast(


### PR DESCRIPTION
Fixes issue mentioned by @xari in [the latest comment of this ticket](https://bbpteam.epfl.ch/project/issues/browse/BBPP154-231)

Right now the request to create a new project will fail if a long description (>255 chars) is added to the new project. The error happens because we try to pass the project description to KC when creating admin/member groups and KC has a hard limit of 255 chars for description. 

![Screenshot from 2024-04-24 15-23-27](https://github.com/BlueBrain/virtual-lab-api/assets/11242410/3a6b69d2-61a1-4d94-91ce-15d5fc863108)

We can either trim the description when creating KC groups or not add any description. In this PR, I've gone with the second option because I don't see much value in adding this description in KC groups. The group names already have enough info imho.

Lemme know if you prefer the first option though (adding a description, but trimming it).