### PR TITLE
Add user invited to project, to the virtual lab too

### DIFF
--- a/virtual_labs/tests/projects/test_project_invite.py
+++ b/virtual_labs/tests/projects/test_project_invite.py
@@ -19,6 +19,7 @@ async def test_invite_user_to_project(
     user_to_invite = "test-1"
     invite_payload = {"email": f"{user_to_invite}@test.com", "role": "admin"}
 
+    # invite user
     response = await client.post(
         f"/virtual-labs/{lab_id}/projects/{project_id}/invites",
         json=invite_payload,
@@ -26,11 +27,21 @@ async def test_invite_user_to_project(
     )
     assert response.status_code == HTTPStatus.OK
 
+    # accept invite
     invite_token = get_invite_token_from_email(f"{user_to_invite}@test.com")
     accept_invite_response = await client.post(
         f"/invites?token={invite_token}", headers=get_headers(username=user_to_invite)
     )
     assert accept_invite_response.status_code == HTTPStatus.OK
+    lab_response = await client.get(
+        f"/virtual-labs/{lab_id}", headers=get_headers(username=user_to_invite)
+    )
+    assert lab_response.status_code == HTTPStatus.OK
+    project_response = await client.get(
+        f"/virtual-labs/{lab_id}/projects/{project_id}",
+        headers=get_headers(username=user_to_invite),
+    )
+    assert project_response.status_code == HTTPStatus.OK
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Implements [BBPP154-236](https://bbpteam.epfl.ch/project/issues/browse/BBPP154-236)

When a user is successfully added to project, they should also be added to the corresponding virtual lab even if they were not explicitly invited to the lab. 

[![Screenshot from 2024-04-29 16-36-42](https://github.com/BlueBrain/virtual-lab-api/assets/11242410/807c2d38-2bc6-4acf-8e55-2edd0364637d)
](url)