### PR TITLE
Add non nullable field "entity" to virtual lab table and DTOs

### DIFF
--- a/alembic/versions/891ce04bd30a_add_entity_column_to_lab.py
+++ b/alembic/versions/891ce04bd30a_add_entity_column_to_lab.py
@@ -1,0 +1,34 @@
+"""Add entity column to lab
+
+Revision ID: 891ce04bd30a
+Revises: aa81eeb4dad6
+Create Date: 2024-05-02 10:08:57.981605
+
+"""
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "891ce04bd30a"
+down_revision: Union[str, None] = "aa81eeb4dad6"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    # Add column for entity
+    op.add_column("virtual_lab", sa.Column("entity", sa.String()))
+
+    # Add default value "EPFL, Switzerland" for all existing labs
+    lab_table = sa.table("virtual_lab", sa.column("entity"))
+    op.execute(lab_table.update().values({"entity": "EPFL, Switzerland"}))
+
+    # Now make `entity` table non-nullable
+    op.alter_column("virtual_lab", "entity", nullable=False)
+
+
+def downgrade() -> None:
+    op.drop_column("virtual_lab", "entity")

--- a/virtual_labs/domain/labs.py
+++ b/virtual_labs/domain/labs.py
@@ -20,6 +20,7 @@ class VirtualLabBase(BaseModel):
     description: str
     reference_email: EmailStr
     budget: float
+    entity: str
 
     @field_validator("budget")
     @classmethod
@@ -36,6 +37,7 @@ class VirtualLabUpdate(BaseModel):
     reference_email: EmailStr | None = None
     budget: float | None = None
     plan_id: int | None = None
+    entity: str | None = None
 
     @field_validator("budget")
     @classmethod

--- a/virtual_labs/infrastructure/db/models.py
+++ b/virtual_labs/infrastructure/db/models.py
@@ -36,6 +36,7 @@ class VirtualLab(Base):
     name = Column(String(250), index=True)
     description = Column(Text)
     reference_email = Column(String(255))
+    entity = Column(String, nullable=False)
 
     budget = Column(
         Float, CheckConstraint("budget > 0"), nullable=False

--- a/virtual_labs/repositories/labs.py
+++ b/virtual_labs/repositories/labs.py
@@ -117,6 +117,7 @@ async def create_virtual_lab(db: AsyncSession, lab: VirtualLabDbCreate) -> Virtu
         projects=[],
         budget=lab.budget,
         plan_id=lab.plan_id,
+        entity=lab.entity,
     )
     db.add(db_lab)
     await db.commit()
@@ -142,6 +143,7 @@ async def update_virtual_lab(
                 "updated_at": func.now(),
                 "budget": data_to_update.get("budget", current.budget),
                 "plan_id": data_to_update.get("plan_id", current.plan_id),
+                "entity": data_to_update.get("entity", current.entity),
             }
         )
     )

--- a/virtual_labs/tests/conftest.py
+++ b/virtual_labs/tests/conftest.py
@@ -44,6 +44,7 @@ async def mock_lab_create(
         "reference_email": "user@test.org",
         "budget": 10000,
         "plan_id": 1,
+        "entity": "EPFL, Switzerland",
     }
     headers = get_headers()
     response = await client.post(

--- a/virtual_labs/tests/test_delete_lab.py
+++ b/virtual_labs/tests/test_delete_lab.py
@@ -24,6 +24,7 @@ async def mock_lab_create(
         "reference_email": "user@test.org",
         "budget": 10,
         "plan_id": 3,
+        "entity": "EPFL, Switzerland",
     }
     headers = get_headers()
     response = await client.post(

--- a/virtual_labs/tests/test_get_all_labs.py
+++ b/virtual_labs/tests/test_get_all_labs.py
@@ -20,6 +20,7 @@ async def create_mock_lab(
         "reference_email": "user@test.org",
         "budget": 10,
         "plan_id": 1,
+        "entity": "EPFL, Switzerland",
     }
     headers = headers_for_test_user
     response = await client.post(

--- a/virtual_labs/tests/test_get_lab.py
+++ b/virtual_labs/tests/test_get_lab.py
@@ -20,6 +20,7 @@ async def mock_lab_create(
         "reference_email": "user@test.org",
         "budget": 10,
         "plan_id": 1,
+        "entity": "EPFL, Switzerland",
     }
     headers = get_headers()
     lab_create_response = await client.post(

--- a/virtual_labs/tests/test_invite_user_to_lab.py
+++ b/virtual_labs/tests/test_invite_user_to_lab.py
@@ -23,6 +23,7 @@ async def mock_lab_create(
         "reference_email": "user@test.org",
         "budget": 10,
         "plan_id": 1,
+        "entity": "EPFL, Switzerland",
     }
     headers = get_headers()
     response = await client.post(

--- a/virtual_labs/tests/test_lab_creation.py
+++ b/virtual_labs/tests/test_lab_creation.py
@@ -22,6 +22,7 @@ async def mock_lab_create(
         "reference_email": "user@test.org",
         "budget": 10,
         "plan_id": 1,
+        "entity": "EPFL, Switzerland",
     }
     headers = get_headers()
     response = await client.post(
@@ -47,6 +48,7 @@ async def mock_lab_create_with_users(
         "reference_email": "user@test.org",
         "budget": 10,
         "plan_id": 1,
+        "entity": "EPFL, Switzerland",
         "include_members": [
             {"email": "test-1@test.com", "role": "admin"},
             {"email": "test-2@test.com", "role": "member"},
@@ -141,6 +143,7 @@ async def test_virtual_lab_created_with_users(
             "budget": 10.0,
             "id": lab_id,
             "plan_id": 1,
+            "entity": "EPFL, Switzerland",
             "created_at": actual_response["virtual_lab"]["created_at"],
         },
         "successful_invites": [

--- a/virtual_labs/tests/test_lab_search.py
+++ b/virtual_labs/tests/test_lab_search.py
@@ -19,6 +19,7 @@ async def mock_lab_create(
         "reference_email": "user@test.org",
         "budget": 10,
         "plan_id": 1,
+        "entity": "EPFL, Switzerland",
     }
     headers = get_headers()
     response = await client.post(

--- a/virtual_labs/tests/test_restrict_invalid_access_to_lab.py
+++ b/virtual_labs/tests/test_restrict_invalid_access_to_lab.py
@@ -23,6 +23,7 @@ async def mock_lab_create(
         "reference_email": "user@test.org",
         "budget": 10,
         "plan_id": 1,
+        "entity": "EPFL, Switzerland",
     }
     headers = get_headers(member_user)
     response = await client.post(

--- a/virtual_labs/tests/test_update_lab.py
+++ b/virtual_labs/tests/test_update_lab.py
@@ -19,6 +19,7 @@ async def mock_lab_create(
         "reference_email": "user@test.org",
         "budget": 10,
         "plan_id": 1,
+        "entity": "EPFL, Switzerland",
     }
     headers = get_headers()
     response = await client.post(
@@ -39,7 +40,12 @@ async def test_update_lab(
 ) -> None:
     client, lab_id, headers = mock_lab_create
 
-    update_body = {"name": "New Name", "plan_id": 2, "budget": 200}
+    update_body = {
+        "name": "New Name",
+        "plan_id": 2,
+        "budget": 200,
+        "entity": "Max Planck",
+    }
     response = await client.patch(
         f"/virtual-labs/{lab_id}", headers=headers, json=update_body
     )
@@ -48,3 +54,4 @@ async def test_update_lab(
     assert data["name"] == update_body["name"]
     assert data["plan_id"] == update_body["plan_id"]
     assert data["budget"] == update_body["budget"]
+    assert data["entity"] == update_body["entity"]

--- a/virtual_labs/tests/utils.py
+++ b/virtual_labs/tests/utils.py
@@ -58,6 +58,7 @@ async def create_mock_lab(
         "reference_email": "user@test.org",
         "budget": 10,
         "plan_id": 1,
+        "entity": "EPFL, Switzerland",
     }
     headers = get_headers(owner_username)
     response = await client.post(
@@ -78,6 +79,7 @@ async def create_mock_lab_with_project(
         "reference_email": "user@test.org",
         "budget": 10,
         "plan_id": 1,
+        "entity": "EPFL, Switzerland",
     }
     headers = get_headers(owner_username)
     lab_response = await client.post(

--- a/virtual_labs/usecases/labs/lab_with_not_deleted_projects.py
+++ b/virtual_labs/usecases/labs/lab_with_not_deleted_projects.py
@@ -77,4 +77,5 @@ def lab_with_not_deleted_projects(
         deleted=domain_lab.deleted,
         deleted_at=domain_lab.deleted_at,
         updated_at=domain_lab.updated_at,
+        entity=domain_lab.entity,
     )


### PR DESCRIPTION
Implements [BBPP154-239](https://bbpteam.epfl.ch/project/issues/browse/BBPP154-239)

A non-nullable string  column `entity` is now added to VirtualLab table. This field is required when calling the create lab endpoint and will be returned in the response for lab crud endpoints.