### PR TITLE
Remove load_env since env files are being loaded by priority later

### DIFF
--- a/virtual_labs/infrastructure/settings.py
+++ b/virtual_labs/infrastructure/settings.py
@@ -1,11 +1,8 @@
 from typing import Any, Literal, Optional
 
-from dotenv import load_dotenv
 from pydantic import EmailStr, PostgresDsn, ValidationInfo, field_validator
 from pydantic_core import MultiHostUrl, Url
 from pydantic_settings import BaseSettings, SettingsConfigDict
-
-load_dotenv("")
 
 
 class Settings(BaseSettings):


### PR DESCRIPTION
Since we are already loading env files on [this line](https://github.com/BlueBrain/virtual-lab-api/pull/47/files#diff-65f79d014eab3364839020e18f8f67dcb92825cb22c12d97736b38945f72acc7R11) we don't need to load them again in line 8. Thanks @genric for pointing this out.