### PR TITLE
Change status code because precondition through headers is not relevant

### DIFF
--- a/virtual_labs/tests/projects/test_project_invite.py
+++ b/virtual_labs/tests/projects/test_project_invite.py
@@ -62,4 +62,4 @@ async def test_user_already_in_project_cannot_be_reinvited(
         json=invite_payload,
         headers=headers,
     )
-    assert reinvite_user_response.status_code == HTTPStatus.PRECONDITION_FAILED
+    assert reinvite_user_response.status_code == HTTPStatus.UNPROCESSABLE_ENTITY

--- a/virtual_labs/tests/test_invite_user_to_lab.py
+++ b/virtual_labs/tests/test_invite_user_to_lab.py
@@ -112,7 +112,7 @@ async def test_user_already_in_lab_cannot_be_reinvited(
     invite_response = await client.post(
         f"/virtual-labs/{lab_id}/invites", headers=headers, json=invite
     )
-    assert invite_response.status_code == HTTPStatus.PRECONDITION_FAILED
+    assert invite_response.status_code == HTTPStatus.UNPROCESSABLE_ENTITY
     assert (
         "User with email test@test.com is already in lab"
         in invite_response.json()["message"]

--- a/virtual_labs/usecases/labs/invite_user_to_lab.py
+++ b/virtual_labs/usecases/labs/invite_user_to_lab.py
@@ -70,7 +70,7 @@ async def invite_user_to_lab(
             )
             raise VliError(
                 message=f"User with email {invite_details.email} is already in lab {lab.name}",
-                http_status_code=HTTPStatus.PRECONDITION_FAILED,
+                http_status_code=HTTPStatus.UNPROCESSABLE_ENTITY,
                 error_code=VliErrorCode.ENTITY_ALREADY_EXISTS,
             )
 

--- a/virtual_labs/usecases/project/invite_user_to_project.py
+++ b/virtual_labs/usecases/project/invite_user_to_project.py
@@ -63,7 +63,7 @@ async def invite_user_to_project(
             )
             raise VliError(
                 message=f"User with email {invite_details.email} is already in project {project.name}",
-                http_status_code=HTTPStatus.PRECONDITION_FAILED,
+                http_status_code=HTTPStatus.UNPROCESSABLE_ENTITY,
                 error_code=VliErrorCode.ENTITY_ALREADY_EXISTS,
             )
 


### PR DESCRIPTION
Change status code from 412 to 422 because the former is used when the condition defined by the If-Unmodified-Since or If-None-Match which is not the case here.