### PR TITLE
Add endpoint to retrieve count of all users in BBP

### DIFF
--- a/virtual_labs/api.py
+++ b/virtual_labs/api.py
@@ -15,6 +15,7 @@ from virtual_labs.core.schemas import api
 from virtual_labs.infrastructure.db.config import session_pool
 from virtual_labs.infrastructure.settings import settings
 from virtual_labs.routes.billing import router as billing_router
+from virtual_labs.routes.common import router as common_router
 from virtual_labs.routes.invites import router as invite_router
 from virtual_labs.routes.labs import router as virtual_lab_router
 from virtual_labs.routes.plans import router as plans_router
@@ -101,6 +102,7 @@ def health() -> str:
     return "OK"
 
 
+base_router.include_router(common_router)
 base_router.include_router(project_router)
 base_router.include_router(virtual_lab_router)
 base_router.include_router(plans_router)

--- a/virtual_labs/domain/user.py
+++ b/virtual_labs/domain/user.py
@@ -43,6 +43,12 @@ class ShortenedUser(BaseModel):
         # populate_by_name = True
 
 
+class AllUsersCount(BaseModel):
+    total: int = Field(
+        description="Count of all users in BBP keycloak (including the ones that may not have not explicitly signed into OBP or have any virtual labs)"
+    )
+
+
 class UserWithInviteStatus(ShortenedUser):
     invite_accepted: bool
     role: UserRoleEnum

--- a/virtual_labs/repositories/user_repo.py
+++ b/virtual_labs/repositories/user_repo.py
@@ -83,6 +83,9 @@ class UserQueryRepository:
         current_groups = [group.id for group in self.retrieve_user_groups(user_id)]
         return group_id in current_groups
 
+    def get_all_users_count(self) -> int:
+        return len(self.Kc.get_users())
+
 
 class UserMutationRepository:
     Kc: KeycloakAdmin

--- a/virtual_labs/routes/common.py
+++ b/virtual_labs/routes/common.py
@@ -1,0 +1,16 @@
+from fastapi import APIRouter, Depends
+
+from virtual_labs.domain.labs import LabResponse
+from virtual_labs.domain.user import AllUsersCount
+from virtual_labs.infrastructure.kc.auth import verify_jwt
+from virtual_labs.infrastructure.kc.models import AuthUser
+from virtual_labs.usecases.users.get_count_of_all_users import get_count_of_all_users
+
+router = APIRouter()
+
+
+@router.get("/users_count", response_model=LabResponse[AllUsersCount])
+async def get_all_users_count(
+    auth: tuple[AuthUser, str] = Depends(verify_jwt),
+) -> LabResponse[AllUsersCount]:
+    return await get_count_of_all_users()

--- a/virtual_labs/tests/test_get_total_users.py
+++ b/virtual_labs/tests/test_get_total_users.py
@@ -1,0 +1,14 @@
+import pytest
+from httpx import AsyncClient
+
+from virtual_labs.tests.utils import get_headers
+
+
+@pytest.mark.asyncio
+async def test_get_total_users(async_test_client: AsyncClient) -> None:
+    client = async_test_client
+    headers = get_headers()
+    response = await client.get("/users_count", headers=headers)
+    assert response.status_code == 200
+    total_users = response.json()["data"]["total"]
+    assert total_users == 3

--- a/virtual_labs/usecases/users/__init__.py
+++ b/virtual_labs/usecases/users/__init__.py
@@ -1,0 +1,5 @@
+from .get_count_of_all_users import get_count_of_all_users
+
+__all__ = [
+    "get_count_of_all_users",
+]

--- a/virtual_labs/usecases/users/get_count_of_all_users.py
+++ b/virtual_labs/usecases/users/get_count_of_all_users.py
@@ -1,0 +1,24 @@
+from http import HTTPStatus
+
+from loguru import logger
+
+from virtual_labs.core.exceptions.api_error import VliError, VliErrorCode
+from virtual_labs.domain.labs import LabResponse
+from virtual_labs.domain.user import AllUsersCount
+from virtual_labs.repositories.user_repo import UserQueryRepository
+
+
+async def get_count_of_all_users() -> LabResponse[AllUsersCount]:
+    try:
+        user_repo = UserQueryRepository()
+        return LabResponse(
+            message="Total users in BBP",
+            data=AllUsersCount(total=user_repo.get_all_users_count()),
+        )
+    except Exception as error:
+        logger.warning(f"Error when retrieving total users {error}")
+        raise VliError(
+            message="Error when retrieving total users",
+            http_status_code=HTTPStatus.INTERNAL_SERVER_ERROR,
+            error_code=VliErrorCode.INTERNAL_SERVER_ERROR,
+        )


### PR DESCRIPTION
Implements [BBPP134-1679](https://bbpteam.epfl.ch/project/issues/browse/BBPP134-1679)

Based on discussions with Ayima and Loris, an endpoint is added to retrieve count of all users in BBP to fulfil [these requirements](https://bbpteam.epfl.ch/project/issues/browse/BBPP134-1670) in the frontend.

![Screenshot from 2024-05-07 15-59-57](https://github.com/BlueBrain/virtual-lab-api/assets/11242410/96ba55af-ea31-4bf1-899e-e25683659000)


