### PR TITLE
BUGFIX // Use group name to append acls to enable users to create nexus resource

### DIFF
--- a/virtual_labs/external/nexus/create_organization.py
+++ b/virtual_labs/external/nexus/create_organization.py
@@ -15,8 +15,8 @@ from virtual_labs.infrastructure.kc.auth import get_client_token
 async def create_nexus_organization(
     nexus_org_id: UUID4,
     description: str | None,
-    admin_group_id: str,
-    member_group_id: str,
+    admin_group_name: str,
+    member_group_name: str,
 ) -> NexusOrganization:
     transport = httpx.AsyncHTTPTransport(retries=3)
     async with httpx.AsyncClient(transport=transport) as httpx_client:
@@ -33,7 +33,7 @@ async def create_nexus_organization(
         # Append acls to the admin group
         admin_acls = await nexus_org_interface.append_org_acls(
             org_id=nexus_org_id,
-            group_id=admin_group_id,
+            group_name=admin_group_name,
             permissions=virtual_lab_admin_acls,
             rev=latest_acl,
         )
@@ -42,7 +42,7 @@ async def create_nexus_organization(
 
         await nexus_org_interface.append_org_acls(
             org_id=nexus_org_id,
-            group_id=member_group_id,
+            group_name=member_group_name,
             permissions=virtual_lab_member_acls,
             rev=admin_acls.rev,
         )

--- a/virtual_labs/external/nexus/organization_interface.py
+++ b/virtual_labs/external/nexus/organization_interface.py
@@ -111,7 +111,7 @@ class NexusOrganizationInterface:
         self,
         *,
         org_id: UUID4,
-        group_id: str,
+        group_name: str,
         rev: int,
         permissions: list[str] | None = None,
     ) -> NexusAcls:
@@ -129,7 +129,7 @@ class NexusOrganizationInterface:
                             "identity": {
                                 "@type": "Group",
                                 "realm": settings.KC_REALM_NAME,
-                                "group": str(group_id),
+                                "group": str(group_name),
                             },
                         },
                     ],
@@ -141,7 +141,7 @@ class NexusOrganizationInterface:
             return NexusAcls(**data)
         except Exception as ex:
             logger.error(
-                f"Error when adding acls for lab {org_id}, group {group_id}: {ex}. Response {response.json()}"
+                f"Error when adding acls for lab {org_id}, group {group_name}: {ex}. Response {response.json()}"
             )
             raise NexusError(
                 message=f"Error when adding acls for lab {org_id}",

--- a/virtual_labs/external/nexus/project_instance.py
+++ b/virtual_labs/external/nexus/project_instance.py
@@ -27,8 +27,8 @@ async def instantiate_nexus_project(
     virtual_lab_id: UUID4,
     project_id: UUID4,
     description: str | None,
-    admin_group_id: str,
-    member_group_id: str,
+    admin_group_name: str,
+    member_group_name: str,
     auth: Tuple[AuthUser, str],
 ) -> str:
     transport = httpx.AsyncHTTPTransport(retries=3)
@@ -109,7 +109,7 @@ async def instantiate_nexus_project(
         appended_admin_group_acls = await nexus_interface.append_project_acls(
             virtual_lab_id=virtual_lab_id,
             project_id=project_id,
-            group_id=admin_group_id,
+            group_name=admin_group_name,
             permissions=project_admin_acls,
             rev=last_acl_rev,
         )
@@ -119,7 +119,7 @@ async def instantiate_nexus_project(
             nexus_interface.append_project_acls(
                 virtual_lab_id=virtual_lab_id,
                 project_id=project_id,
-                group_id=member_group_id,
+                group_name=member_group_name,
                 permissions=project_member_acls,
                 rev=appended_admin_group_acls.rev,
             ),

--- a/virtual_labs/external/nexus/project_interface.py
+++ b/virtual_labs/external/nexus/project_interface.py
@@ -150,7 +150,7 @@ class NexusProjectInterface:
         *,
         virtual_lab_id: UUID4,
         project_id: UUID4,
-        group_id: str,
+        group_name: str,
         rev: int,
         permissions: List[str] | None = None,
     ) -> NexusAcls:
@@ -168,7 +168,7 @@ class NexusProjectInterface:
                             "identity": {
                                 "@type": "Group",
                                 "realm": settings.KC_REALM_NAME,
-                                "group": str(group_id),
+                                "group": str(group_name),
                             },
                         },
                     ],

--- a/virtual_labs/infrastructure/kc/models.py
+++ b/virtual_labs/infrastructure/kc/models.py
@@ -1,4 +1,4 @@
-from typing import Annotated, Any, List
+from typing import Annotated, Any, List, TypedDict
 
 from pydantic import UUID4, BaseModel, EmailStr, Field
 
@@ -52,3 +52,6 @@ class ClientToken(BaseModel):
 
     class Config:
         from_attributes = True
+
+
+CreatedGroup = TypedDict("CreatedGroup", {"id": str, "name": str})

--- a/virtual_labs/repositories/group_repo.py
+++ b/virtual_labs/repositories/group_repo.py
@@ -10,6 +10,7 @@ from virtual_labs.core.types import UserRoleEnum
 from virtual_labs.domain.project import ProjectCreationBody
 from virtual_labs.infrastructure.kc.config import kc_realm
 from virtual_labs.infrastructure.kc.models import (
+    CreatedGroup,
     GroupRepresentation,
     UserRepresentation,
 )
@@ -57,21 +58,18 @@ class GroupMutationRepository:
         vl_id: UUID4,
         vl_name: str,
         role: UserRoleEnum,
-    ) -> str:
+    ) -> CreatedGroup:
         """
         NOTE: you can not set the ID even in the docs says that is Optional
         virtual lab group must be following this format
         vlab/vl-app-id/role
         """
         try:
-            group_id = self.Kc.create_group(
-                {"name": "vlab/{}/{}".format(vl_id, role.value)}
-            )
+            group_name = "vlab/{}/{}".format(vl_id, role.value)
+            group_id = self.Kc.create_group({"name": group_name})
 
-            return cast(
-                str,
-                group_id,
-            )
+            return {"id": group_id, "name": group_name}
+
         # TODO: Add custom Keycloak error class to catch KeyClak errors from keycloak dependencies that are not type safe.
         except Exception as error:
             logger.error(
@@ -89,20 +87,18 @@ class GroupMutationRepository:
         project_id: UUID4,
         role: UserRoleEnum,
         payload: ProjectCreationBody,
-    ) -> str | None:
+    ) -> CreatedGroup | None:
         """
         NOTE: you can not set the ID even in the docs says that is Optional
         project group must be following this format
         proj/virtual_lab_id/project_id/role
         """
+        group_name = "proj/{}/{}/{}".format(virtual_lab_id, project_id, role.value)
         group_id = self.Kc.create_group(
-            {"name": "proj/{}/{}/{}".format(virtual_lab_id, project_id, role.value)},
+            {"name": group_name},
         )
 
-        return cast(
-            str | None,
-            group_id,
-        )
+        return {"id": group_id, "name": group_name}
 
     def delete_group(self, *, group_id: str) -> Any | Dict[str, str]:
         return self.Kc.delete_group(group_id=group_id)

--- a/virtual_labs/tests/projects/test_project_data_update.py
+++ b/virtual_labs/tests/projects/test_project_data_update.py
@@ -125,7 +125,6 @@ async def test_vlm_update_project_name_with_existing_one(
 ) -> None:
     client = async_test_client
     vl_projects, headers = mock_create_full_vl_projects
-    print("vl-projects", vl_projects)
     project_id = vl_projects[0]["id"]
     virtual_lab_id = vl_projects[0]["virtual_lab_id"]
 

--- a/virtual_labs/usecases/project/create_new_project.py
+++ b/virtual_labs/usecases/project/create_new_project.py
@@ -149,26 +149,26 @@ async def create_new_project_use_case(
         )
 
     try:
-        admin_group_id = gmr.create_project_group(
+        admin_group = gmr.create_project_group(
             virtual_lab_id=virtual_lab_id,
             project_id=project_id,
             payload=payload,
             role=UserRoleEnum.admin,
         )
 
-        member_group_id = gmr.create_project_group(
+        member_group = gmr.create_project_group(
             virtual_lab_id=virtual_lab_id,
             project_id=project_id,
             payload=payload,
             role=UserRoleEnum.member,
         )
 
-        assert admin_group_id is not None
-        assert member_group_id is not None
+        assert admin_group is not None
+        assert member_group is not None
 
         umr.attach_user_to_group(
             user_id=user_id,
-            group_id=admin_group_id,
+            group_id=admin_group["id"],
         )
 
     except AssertionError:
@@ -197,14 +197,14 @@ async def create_new_project_use_case(
             virtual_lab_id=virtual_lab_id,
             project_id=project_id,
             description=payload.description,
-            admin_group_id=admin_group_id,
-            member_group_id=member_group_id,
+            admin_group_name=admin_group["name"],
+            member_group_name=member_group["name"],
             auth=auth,
         )
     except NexusError as ex:
         logger.error(f"Error during creating project instance due nexus error ({ex})")
-        gmr.delete_group(group_id=admin_group_id)
-        gmr.delete_group(group_id=member_group_id)
+        gmr.delete_group(group_id=admin_group["id"])
+        gmr.delete_group(group_id=member_group["id"])
 
         raise VliError(
             error_code=VliErrorCode.EXTERNAL_SERVICE_ERROR,
@@ -219,8 +219,8 @@ async def create_new_project_use_case(
             payload=payload,
             virtual_lab_id=virtual_lab_id,
             nexus_project_id=nexus_project_id,
-            admin_group_id=admin_group_id,
-            member_group_id=member_group_id,
+            admin_group_id=admin_group["id"],
+            member_group_id=member_group["id"],
             owner_id=user_id,
         )
 


### PR DESCRIPTION
### Problem

Right now users (admins or members) cannot create resources in a project that they belong to because nexus replies with 403 Forbidden. Why I query my user identities (using my user token) by querying `https://sbo-nexus-delta.shapes-registry.org/v1/identities` I see group names, for example:

```
     {
       "@id": "https://sbo-nexus-delta.shapes-registry.org/v1/realms/SBO/groups/proj/cfcc4437-f251-4da3-9537-09145c2266bd/d968738e-5c37-4c5a-9cc4-392a9ee2b15e/admin",
       "@type": "Group",
       "group": "/proj/cfcc4437-f251-4da3-9537-09145c2266bd/d968738e-5c37-4c5a-9cc4-392a9ee2b15e/admin", // <------------ group name, not group id
       "realm": "SBO"
     }
``` 

When I query project acls `https://sbo-nexus-delta.shapes-registry.org/v1/acls/d4a1e6ab-ba81-4f00-bf57-818b081843a3/0d71e1e5-cbd7-43d4-a4d5-fb4878992c0c?self=false` using the token of virtual lab client, however, I see group ids:
```
 {
          "identity": {
            "@id": "https://sbo-nexus-delta.shapes-registry.org/v1/realms/SBO/groups/fe6840f6-e75a-4d51-a4f3-3d597bce1388",
            "@type": "Group",
            "group": "fe6840f6-e75a-4d51-a4f3-3d597bce1388", // <------------------------------------- Oops group id, not group name
            "realm": "SBO"
          },
          "permissions": [
            "projects/read",
            "views/query",
            "resources/write",
            "resources/read",
            ... // few other permissions
          ]
}
```

When I append acls by group name, instead of group id then I am able to create resources on the project using my GH user token, hence this PR.

### Caveat

Unfortunately, I am not able to create resources on the project **when I use local instance of virtual lab server** (which uses local delta). I tried using both - group ids (like we are doing in current `main` branch) and group names (like this PR does). I think it's mainly because when I query `test` user's identity (`http://localhost/v1/identities`), I never get the "Group" @type identities from delta and I can't figure out why.  This makes the change in this PR difficult to test locally - manually or through an automated test, but note that resource creation is failing in current `main` branch also so there's no regression per say.


## Notes

- If I query my identities (`https://sbo-nexus-delta.shapes-registry.org/v1/identities`) right after creating a project in core-web-app aws deployment I don't see the project Group identity right away. It takes a few retries to get the latest identities.
- [This](https://bluebrainproject.slack.com/archives/G013PKBUHT2/p1720084118669319) slack thread is where I posted the problem and got helpful suggestions from @olivergrabinski and @crisely09 

