### PR TITLE
Prepend slash to group name in acls to match group names in identities

### DIFF
--- a/virtual_labs/external/nexus/organization_interface.py
+++ b/virtual_labs/external/nexus/organization_interface.py
@@ -129,7 +129,7 @@ class NexusOrganizationInterface:
                             "identity": {
                                 "@type": "Group",
                                 "realm": settings.KC_REALM_NAME,
-                                "group": str(group_name),
+                                "group": f"/{group_name}",
                             },
                         },
                     ],

--- a/virtual_labs/external/nexus/project_interface.py
+++ b/virtual_labs/external/nexus/project_interface.py
@@ -168,7 +168,7 @@ class NexusProjectInterface:
                             "identity": {
                                 "@type": "Group",
                                 "realm": settings.KC_REALM_NAME,
-                                "group": str(group_name),
+                                "group": f"/{group_name}",
                             },
                         },
                     ],


### PR DESCRIPTION
Even after the changes made in PR #88 I am unable to create resources on project that I am an admin of. I think its because when I query my user identities I see a slash in the beginning of group name but when I query acls for a org/project, I don't see a slash. 

![Screenshot from 2024-07-08 18-06-52](https://github.com/BlueBrain/virtual-lab-api/assets/11242410/a72aad21-c68e-401f-bdb6-6176766a18db)
User identities

![Screenshot from 2024-07-08 18-15-06](https://github.com/BlueBrain/virtual-lab-api/assets/11242410/ff985b59-7065-4e0d-9a71-2bd608ddaff8)

Acls for a project

Therefore, in this PR I prepend group name with slash when adding acls.

I cannot test this change manually/through automated tests for the same reason as specified in PR #88 