### PR TITLE
Add more cross project resolvers for production

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -1,4 +1,3 @@
 KC_SERVER_URI="http://localhost:9090/"
 NEXUS_DELTA_URI="http://localhost:8080/v1"
 CORS_ORIGINS=["http://localhost:3000"]
-NEXUS_CROSS_RESOLVER_PROJECTS=["neurosciencegraph/datamodels"]

--- a/.env.development
+++ b/.env.development
@@ -1,3 +1,4 @@
 KC_SERVER_URI="http://localhost:9090/"
 NEXUS_DELTA_URI="http://localhost:8080/v1"
 CORS_ORIGINS=["http://localhost:3000"]
+NEXUS_CROSS_RESOLVER_PROJECTS=["neurosciencegraph/datamodels"]

--- a/.env.production
+++ b/.env.production
@@ -1,0 +1,1 @@
+NEXUS_CROSS_RESOLVER_PROJECTS=["public/ephys","public/thalamus","public/ngv","public/multi-vesicular-release","public/hippocampus","public/topological-sampling","bbp/lnmce","public/ngv-anatomy","bbp-external/seu","public/forge","public/sscx","bbp/mouselight","public/morphologies","neurosciencegraph/datamodels","bbp/mmb-point-neuron-framework-model"]

--- a/virtual_labs/external/nexus/defaults.py
+++ b/virtual_labs/external/nexus/defaults.py
@@ -28,7 +28,7 @@ ES_VIEWS = [ProjectView(project=pr, viewId=ES_VIEW_ID) for pr in PROJECTS_TO_AGG
 SP_VIEWS = [{"project": f"{pr}", "viewId": SP_VIEW_ID} for pr in PROJECTS_TO_AGGREGATE]
 
 API_MAPPING: List[NexusApiMapping] = []
-DEFAULT_CROSS_RESOLVER_PROJECTS = ["neurosciencegraph/datamodels"]
+
 DEFAULT_RESOLVER_PRIORITY = 50
 DEFAULT_PROJECT_VOCAB = "https://bbp.epfl.ch/ontologies/core/bmo/"
 DEFAULT_API_MAPPING_RESOURCE = "https://bbp.epfl.ch/nexus/v1/resources/neurosciencegraph/datamodels/_/nexus_api_mappings"

--- a/virtual_labs/external/nexus/project_instance.py
+++ b/virtual_labs/external/nexus/project_instance.py
@@ -9,7 +9,6 @@ from virtual_labs.external.nexus.default_mapping import DEFAULT_MAPPING
 from virtual_labs.external.nexus.defaults import (
     CROSS_RESOLVER,
     DEFAULT_API_MAPPING_RESOURCE,
-    DEFAULT_CROSS_RESOLVER_PROJECTS,
     DEFAULT_PROJECT_VOCAB,
     ES_RESOURCE_TYPE,
     ES_VIEW_ID,
@@ -57,12 +56,12 @@ async def instantiate_nexus_project(
             apiMapping=api_mappings_datamodels,
             description=description,
         )
-        # Add the CrossProject resolver pointing to the neurosciencegraph/datamodels project
+        # Add the CrossProject resolver pointing to projects with public data
         await nexus_interface.create_resolver(
             virtual_lab_id=virtual_lab_id,
             project_id=project_id,
             type=CROSS_RESOLVER,
-            projects=DEFAULT_CROSS_RESOLVER_PROJECTS,
+            projects=settings.NEXUS_CROSS_RESOLVER_PROJECTS,
             identities=[
                 {
                     "realm": settings.KC_REALM_NAME,

--- a/virtual_labs/infrastructure/settings.py
+++ b/virtual_labs/infrastructure/settings.py
@@ -40,6 +40,7 @@ class Settings(BaseSettings):
         "postgresql+asyncpg://vlm:vlm@localhost:15432/vlm"
     )
     NEXUS_DELTA_URI: Url = Url("http://localhost:8080/v1")
+    NEXUS_CROSS_RESOLVER_PROJECTS: list[str] = []
 
     KC_SERVER_URI: str = "http://localhost:9090/"
     KC_USER_NAME: str = "admin"

--- a/virtual_labs/infrastructure/settings.py
+++ b/virtual_labs/infrastructure/settings.py
@@ -40,7 +40,7 @@ class Settings(BaseSettings):
         "postgresql+asyncpg://vlm:vlm@localhost:15432/vlm"
     )
     NEXUS_DELTA_URI: Url = Url("http://localhost:8080/v1")
-    NEXUS_CROSS_RESOLVER_PROJECTS: list[str] = []
+    NEXUS_CROSS_RESOLVER_PROJECTS: list[str] = ["neurosciencegraph/datamodels"]
 
     KC_SERVER_URI: str = "http://localhost:9090/"
     KC_USER_NAME: str = "admin"


### PR DESCRIPTION
The resolver that is created on project instantiation should contain more projects/buckets to enable access to public data.

Particular use case: fetching Emodels and Morphologies from `bbp/mmb-point-neuron-framework-model` for created by the user ME-models stored in vlab/project bucket.