### PR TITLE
Use SBO suite projects in aggregated ES/SPARQL views

### DIFF
--- a/.env.production
+++ b/.env.production
@@ -1,1 +1,0 @@
-NEXUS_CROSS_RESOLVER_PROJECTS=["public/ephys","public/thalamus","public/ngv","public/multi-vesicular-release","public/hippocampus","public/topological-sampling","bbp/lnmce","public/ngv-anatomy","bbp-external/seu","public/forge","public/sscx","bbp/mouselight","public/morphologies","neurosciencegraph/datamodels","bbp/mmb-point-neuron-framework-model"]

--- a/env-prep/init/init.py
+++ b/env-prep/init/init.py
@@ -45,6 +45,28 @@ acls_payload = {
     ],
 }
 
+public_project_acl = {
+    "@type": "Append",
+    "acl": [
+        {
+            "identity": {
+                "realm": "obp-realm",
+                "@type": "Authenticated",
+            },
+            "permissions": [
+                "version/read",
+                "projects/read",
+                "realms/read",
+                "resources/read",
+                "views/query",
+                "quotas/read",
+                "supervision/read",
+                "export/run",
+            ],
+        }
+    ],
+}
+
 
 org_payload = json.dumps({"description": "organization"})
 project_payload = json.dumps({"description": "organization"})
@@ -56,6 +78,10 @@ KC_PASSWORD = "admin"
 KC_CLIENT_ID = "obpapp"
 KC_CLIENT_SECRET = "obp-secret"
 KC_REALM_NAME = "obp-realm"
+
+
+def print_response(nexus_conn):
+    print(nexus_conn.getresponse().read().decode("utf-8"), "\n")
 
 
 nexus_conn = http.client.HTTPConnection("localhost", 8080)
@@ -113,27 +139,38 @@ client_headers = {
 
 print("---- #1 append ACLs to the user 'test' \n")
 nexus_conn.request("PATCH", "/v1/acls", json.dumps(acls_payload), client_headers)
-res = nexus_conn.getresponse()
-data = res.read()
-print(data.decode("utf-8"), "\n")
+print_response(nexus_conn)
 
 
 print("---- #2 create neurosciencegraph/datamodels (org/project) \n")
 nexus_conn.request("PUT", "/v1/orgs/neurosciencegraph", org_payload, client_headers)
-res = (nexus_conn.getresponse()).read()
+print_response(nexus_conn)
+
 nexus_conn.request(
     "PUT", "/v1/projects/neurosciencegraph/datamodels", project_payload, client_headers
 )
-res = nexus_conn.getresponse()
-print(res.read().decode("utf-8"), "\n")
+print_response(nexus_conn)
+
+nexus_conn.request(
+    "PATCH",
+    "/v1/acls/neurosciencegraph/datamodels",
+    json.dumps(public_project_acl),
+    client_headers,
+)
+print_response(nexus_conn)
 
 
 print("---- #3- create bbp/atlas (org/project) \n")
 nexus_conn.request("PUT", "/v1/orgs/bbp", org_payload, client_headers)
-res = (nexus_conn.getresponse()).read()
+print_response(nexus_conn)
+
 nexus_conn.request("PUT", "/v1/projects/bbp/atlas", project_payload, client_headers)
-res = nexus_conn.getresponse()
-print(res.read().decode("utf-8"), "\n")
+print_response(nexus_conn)
+
+nexus_conn.request(
+    "PATCH", "/v1/acls/bbp/atlas", json.dumps(public_project_acl), client_headers
+)
+print_response(nexus_conn)
 
 
 print("---- #4 create dataset es view for  neurosciencegraph/datamodels \n")
@@ -146,8 +183,7 @@ with open(os.path.join(__location__, "es_view_dataset_payload.json")) as f:
         data,
         client_headers,
     )
-    res = nexus_conn.getresponse()
-    print(res.read().decode("utf-8"), "\n")
+    print_response(nexus_conn)
 
 print("---- #5 create dataset es view for  bbp/atlas \n")
 with open(os.path.join(__location__, "es_view_dataset_payload.json")) as f:
@@ -159,8 +195,7 @@ with open(os.path.join(__location__, "es_view_dataset_payload.json")) as f:
         data,
         client_headers,
     )
-    res = nexus_conn.getresponse()
-    print(res.read().decode("utf-8"), "\n")
+    print_response(nexus_conn)
 
 
 print("---- #6 create neuroshapes.org resource\n")
@@ -172,8 +207,7 @@ with open(os.path.join(__location__, "neuroshapes_org_resource.json")) as f:
         data,
         client_headers,
     )
-    res = nexus_conn.getresponse()
-    print(res.read().decode("utf-8"), "\n")
+    print_response(nexus_conn)
 
 
 print("---- #7 create api_mapping_resource\n")
@@ -185,8 +219,7 @@ with open(os.path.join(__location__, "api_mappings_payload.json")) as f:
         data,
         client_headers,
     )
-    res = nexus_conn.getresponse()
-    print(res.read().decode("utf-8"), "\n")
+    print_response(nexus_conn)
 
 
 print("\n------END------\n")

--- a/virtual_labs/external/nexus/defaults.py
+++ b/virtual_labs/external/nexus/defaults.py
@@ -109,7 +109,7 @@ def prep_subtract_identity(
     realm: str,
     user: str,
 ) -> NexusIdentity:
-    return {"realm": realm, "subject": user}
+    return NexusIdentity(realm=realm, subject=user)
 
 
 def prep_default_local_context(vocab: str) -> Dict[str, Any]:

--- a/virtual_labs/external/nexus/models.py
+++ b/virtual_labs/external/nexus/models.py
@@ -32,8 +32,8 @@ class NexusApiMapping(TypedDict):
 
 class NexusIdentity(BaseModel):
     realm: str
-    subject: Optional[str] = None
-    type: Optional[Annotated[str, Field(alias="@type")]] = None
+    subject: str = None
+    type: Annotated[str, Field(serialization_alias="@type")] = None
 
 
 class NexusResource(NexusBase):

--- a/virtual_labs/external/nexus/models.py
+++ b/virtual_labs/external/nexus/models.py
@@ -30,9 +30,10 @@ class NexusApiMapping(TypedDict):
     prefix: str
 
 
-class NexusIdentity(TypedDict):
+class NexusIdentity(BaseModel):
     realm: str
-    subject: str | None
+    subject: Optional[str] = None
+    type: Optional[Annotated[str, Field(alias="@type")]] = None
 
 
 class NexusResource(NexusBase):

--- a/virtual_labs/external/nexus/models.py
+++ b/virtual_labs/external/nexus/models.py
@@ -32,8 +32,8 @@ class NexusApiMapping(TypedDict):
 
 class NexusIdentity(BaseModel):
     realm: str
-    subject: str = None
-    type: Annotated[str, Field(serialization_alias="@type")] = None
+    subject: Optional[str] = None
+    type: Annotated[str | None, Field(serialization_alias="@type")] = None
 
 
 class NexusResource(NexusBase):

--- a/virtual_labs/external/nexus/project_instance.py
+++ b/virtual_labs/external/nexus/project_instance.py
@@ -66,7 +66,11 @@ async def instantiate_nexus_project(
             type=CROSS_RESOLVER,
             projects=sbo_suite_projects,
             identities=[
-                NexusIdentity(realm=settings.KC_REALM_NAME, type="Authenticated")
+                NexusIdentity(realm=settings.KC_REALM_NAME, type="Authenticated"),
+                NexusIdentity(
+                    realm=settings.KC_REALM_NAME,
+                    subject=f"service-account-{settings.KC_CLIENT_ID}",
+                ),
             ],
         )
         await asyncio.gather(

--- a/virtual_labs/external/nexus/project_instance.py
+++ b/virtual_labs/external/nexus/project_instance.py
@@ -67,7 +67,7 @@ async def instantiate_nexus_project(
             identities=[
                 {
                     "realm": settings.KC_REALM_NAME,
-                    "subject": "authenticated",
+                    "subject": "Authenticated",
                 }
             ],
         )

--- a/virtual_labs/external/nexus/project_instance.py
+++ b/virtual_labs/external/nexus/project_instance.py
@@ -14,6 +14,7 @@ from virtual_labs.external.nexus.defaults import (
     ES_VIEW_ID,
     prep_default_local_context,
 )
+from virtual_labs.external.nexus.models import NexusIdentity
 from virtual_labs.external.nexus.project_interface import NexusProjectInterface
 from virtual_labs.infrastructure.kc.auth import get_client_token
 from virtual_labs.infrastructure.kc.models import AuthUser
@@ -65,10 +66,7 @@ async def instantiate_nexus_project(
             type=CROSS_RESOLVER,
             projects=sbo_suite_projects,
             identities=[
-                {
-                    "realm": settings.KC_REALM_NAME,
-                    "@type": "Authenticated",
-                }
+                NexusIdentity(realm=settings.KC_REALM_NAME, type="Authenticated")
             ],
         )
         await asyncio.gather(

--- a/virtual_labs/external/nexus/project_instance.py
+++ b/virtual_labs/external/nexus/project_instance.py
@@ -15,7 +15,7 @@ from virtual_labs.external.nexus.defaults import (
     prep_default_local_context,
 )
 from virtual_labs.external.nexus.project_interface import NexusProjectInterface
-from virtual_labs.infrastructure.kc.auth import KC_SUBJECT, get_client_token
+from virtual_labs.infrastructure.kc.auth import get_client_token
 from virtual_labs.infrastructure.kc.models import AuthUser
 from virtual_labs.infrastructure.settings import settings
 
@@ -67,12 +67,8 @@ async def instantiate_nexus_project(
             identities=[
                 {
                     "realm": settings.KC_REALM_NAME,
-                    "subject": KC_SUBJECT,
-                },
-                {
-                    "realm": settings.KC_REALM_NAME,
                     "subject": "authenticated",
-                },
+                }
             ],
         )
         await asyncio.gather(

--- a/virtual_labs/external/nexus/project_instance.py
+++ b/virtual_labs/external/nexus/project_instance.py
@@ -67,7 +67,7 @@ async def instantiate_nexus_project(
             identities=[
                 {
                     "realm": settings.KC_REALM_NAME,
-                    "subject": "Authenticated",
+                    "@type": "Authenticated",
                 }
             ],
         )

--- a/virtual_labs/external/nexus/project_instance.py
+++ b/virtual_labs/external/nexus/project_instance.py
@@ -15,7 +15,7 @@ from virtual_labs.external.nexus.defaults import (
     prep_default_local_context,
 )
 from virtual_labs.external.nexus.project_interface import NexusProjectInterface
-from virtual_labs.infrastructure.kc.auth import KC_SUBJECT, get_client_token
+from virtual_labs.infrastructure.kc.auth import get_client_token
 from virtual_labs.infrastructure.kc.models import AuthUser
 from virtual_labs.infrastructure.settings import settings
 
@@ -67,7 +67,7 @@ async def instantiate_nexus_project(
             identities=[
                 {
                     "realm": settings.KC_REALM_NAME,
-                    "subject": KC_SUBJECT,
+                    "subject": "authenticated",
                 }
             ],
         )

--- a/virtual_labs/external/nexus/project_instance.py
+++ b/virtual_labs/external/nexus/project_instance.py
@@ -39,6 +39,8 @@ async def instantiate_nexus_project(
         )
         user, _ = auth
 
+        sbo_suite_projects = await nexus_interface.get_sbo_suite_projects()
+
         # get the latest api mapping
         # TODO: to confirm if the api mapping has the full set
         api_mappings_datamodels = (
@@ -61,7 +63,7 @@ async def instantiate_nexus_project(
             virtual_lab_id=virtual_lab_id,
             project_id=project_id,
             type=CROSS_RESOLVER,
-            projects=settings.NEXUS_CROSS_RESOLVER_PROJECTS,
+            projects=sbo_suite_projects,
             identities=[
                 {
                     "realm": settings.KC_REALM_NAME,
@@ -124,11 +126,15 @@ async def instantiate_nexus_project(
             ),
             # Create aggregated elastic search view in the project
             nexus_interface.create_nexus_es_aggregate_view(
-                virtual_lab_id=virtual_lab_id, project_id=project_id
+                virtual_lab_id=virtual_lab_id,
+                project_id=project_id,
+                extra_projects=sbo_suite_projects,
             ),
             # Create aggregated Sparql view in the project
             nexus_interface.create_nexus_sp_aggregate_view(
-                virtual_lab_id=virtual_lab_id, project_id=project_id
+                virtual_lab_id=virtual_lab_id,
+                project_id=project_id,
+                extra_projects=sbo_suite_projects,
             ),
             # Create S3 storage
             nexus_interface.create_s3_storage(

--- a/virtual_labs/external/nexus/project_instance.py
+++ b/virtual_labs/external/nexus/project_instance.py
@@ -15,7 +15,7 @@ from virtual_labs.external.nexus.defaults import (
     prep_default_local_context,
 )
 from virtual_labs.external.nexus.project_interface import NexusProjectInterface
-from virtual_labs.infrastructure.kc.auth import get_client_token
+from virtual_labs.infrastructure.kc.auth import KC_SUBJECT, get_client_token
 from virtual_labs.infrastructure.kc.models import AuthUser
 from virtual_labs.infrastructure.settings import settings
 
@@ -67,8 +67,12 @@ async def instantiate_nexus_project(
             identities=[
                 {
                     "realm": settings.KC_REALM_NAME,
+                    "subject": KC_SUBJECT,
+                },
+                {
+                    "realm": settings.KC_REALM_NAME,
                     "subject": "authenticated",
-                }
+                },
             ],
         )
         await asyncio.gather(

--- a/virtual_labs/external/nexus/project_interface.py
+++ b/virtual_labs/external/nexus/project_interface.py
@@ -512,7 +512,6 @@ class NexusProjectInterface:
             ],
             "priority": priority,
         }
-        logger.info(f"Creating nexus resolver {payload}")
 
         if resolver_id:
             payload["@id"] = resolver_id

--- a/virtual_labs/external/nexus/project_interface.py
+++ b/virtual_labs/external/nexus/project_interface.py
@@ -512,6 +512,7 @@ class NexusProjectInterface:
             ],
             "priority": priority,
         }
+        logger.info(f"Creating nexus resolver {payload}")
 
         if resolver_id:
             payload["@id"] = resolver_id

--- a/virtual_labs/external/nexus/project_interface.py
+++ b/virtual_labs/external/nexus/project_interface.py
@@ -507,7 +507,7 @@ class NexusProjectInterface:
         payload = {
             "@type": type,
             "projects": projects,
-            "identities": [i.__dict__ for i in identities],
+            "identities": [i.model_dump(by_alias=True) for i in identities],
             "priority": priority,
         }
 

--- a/virtual_labs/external/nexus/project_interface.py
+++ b/virtual_labs/external/nexus/project_interface.py
@@ -440,8 +440,8 @@ class NexusProjectInterface:
                         {
                             "permissions": permissions,
                             "identity": {
-                                "realm": identity["realm"],
-                                "subject": identity["subject"],
+                                "realm": identity.realm,
+                                "subject": identity.subject,
                             },
                         },
                     ],
@@ -507,7 +507,7 @@ class NexusProjectInterface:
         payload = {
             "@type": type,
             "projects": projects,
-            "identities": identities,
+            "identities": [i.__dict__ for i in identities],
             "priority": priority,
         }
 

--- a/virtual_labs/external/nexus/project_interface.py
+++ b/virtual_labs/external/nexus/project_interface.py
@@ -507,7 +507,9 @@ class NexusProjectInterface:
         payload = {
             "@type": type,
             "projects": projects,
-            "identities": [i.model_dump(by_alias=True) for i in identities],
+            "identities": [
+                i.model_dump(by_alias=True, exclude_none=True) for i in identities
+            ],
             "priority": priority,
         }
 

--- a/virtual_labs/external/nexus/project_interface.py
+++ b/virtual_labs/external/nexus/project_interface.py
@@ -284,7 +284,7 @@ class NexusProjectInterface:
                 type=NexusErrorValue.CREATE_ES_VIEW_ERROR,
             )
 
-    async def __get_sbo_suite_views(self) -> list[ProjectView]:
+    async def get_sbo_suite_projects(self) -> list[str]:
         try:
             sbo_projects_response = await self.httpx_clt.get(
                 f"{settings.NEXUS_DELTA_URI}/search/suites/sbo", headers=self.headers
@@ -294,13 +294,10 @@ class NexusProjectInterface:
             data = NexusSuiteProjects.model_validate(
                 sbo_projects_response.json()
             ).projects
+
             sbo_projects = data if isinstance(data, list) else [data]
 
-            views = [
-                ProjectView(project=project, viewId=ES_VIEW_ID)
-                for project in sbo_projects
-            ]
-            return views
+            return sbo_projects
         except Exception as ex:
             logger.error(
                 f"Failed to retrieve projects within sbo suite. Response {sbo_projects_response.json()}. Error: {ex}"
@@ -316,11 +313,15 @@ class NexusProjectInterface:
         virtual_lab_id: UUID4,
         project_id: UUID4,
         view_id: str = AG_ES_VIEW_ID,
+        extra_projects: List[str] = [],
     ) -> NexusResource:
         nexus_es_view_url = (
             f"{settings.NEXUS_DELTA_URI}/views/{str(virtual_lab_id)}/{str(project_id)}"
         )
-        sbo_suite_views = await self.__get_sbo_suite_views()
+        extra_views = [
+            ProjectView(project=project, viewId=ES_VIEW_ID)
+            for project in extra_projects
+        ]
         views = (
             [
                 ProjectView(
@@ -329,7 +330,7 @@ class NexusProjectInterface:
                 ),
             ]
             + ES_VIEWS
-            + sbo_suite_views
+            + extra_views
         )
         try:
             response = await self.httpx_clt.post(
@@ -360,13 +361,20 @@ class NexusProjectInterface:
         virtual_lab_id: UUID4,
         project_id: UUID4,
         view_id: str = AG_SP_VIEW_ID,
+        extra_projects: List[str] = [],
     ) -> NexusResource:
         nexus_es_view_url = (
             f"{settings.NEXUS_DELTA_URI}/views/{str(virtual_lab_id)}/{str(project_id)}"
         )
-        views = [
-            {"project": f"{virtual_lab_id}/{project_id}", "viewId": SP_VIEW_ID}
-        ] + SP_VIEWS
+        extra_views = [
+            ProjectView(project=project, viewId=SP_VIEW_ID)
+            for project in extra_projects
+        ]
+        views = (
+            [{"project": f"{virtual_lab_id}/{project_id}", "viewId": SP_VIEW_ID}]
+            + SP_VIEWS
+            + extra_views
+        )
 
         try:
             response = await self.httpx_clt.post(

--- a/virtual_labs/infrastructure/settings.py
+++ b/virtual_labs/infrastructure/settings.py
@@ -40,7 +40,6 @@ class Settings(BaseSettings):
         "postgresql+asyncpg://vlm:vlm@localhost:15432/vlm"
     )
     NEXUS_DELTA_URI: Url = Url("http://localhost:8080/v1")
-    NEXUS_CROSS_RESOLVER_PROJECTS: list[str] = ["neurosciencegraph/datamodels"]
 
     KC_SERVER_URI: str = "http://localhost:9090/"
     KC_USER_NAME: str = "admin"


### PR DESCRIPTION
In fact, the list of projects fetched from SBO suite endpoint will be used to create:
* CrossProject resolver
* Aggregated ES and SPARQL views