### PR TITLE
Add logs to inspect keycloak errors to debug 401 and 403

### DIFF
--- a/virtual_labs/core/authorization/verify_project_read.py
+++ b/virtual_labs/core/authorization/verify_project_read.py
@@ -2,6 +2,7 @@ from functools import wraps
 from http import HTTPStatus as status
 from typing import Any, Callable
 
+from keycloak import KeycloakError  # type:ignore
 from loguru import logger
 from sqlalchemy.exc import NoResultFound, SQLAlchemyError
 
@@ -56,6 +57,15 @@ def verify_project_read(f: Callable[..., Any]) -> Callable[..., Any]:
                 error_code=VliErrorCode.NOT_ALLOWED_OP,
                 http_status_code=status.FORBIDDEN,
                 message="The supplied authentication is not authorized for this action",
+            )
+        except KeycloakError as error:
+            logger.error(f"Keycloak error MESSAGE: {error.__str__}")
+            logger.exception(f"Keycloak get error {error}")
+            raise VliError(
+                error_code=VliErrorCode.INTERNAL_SERVER_ERROR,
+                http_status_code=status.BAD_REQUEST,
+                message="Checking for authorization failed",
+                details=error.__str__,
             )
         except Exception as error:
             logger.exception(f"Unknown error when checking for project_read: {error}")

--- a/virtual_labs/core/authorization/verify_project_write.py
+++ b/virtual_labs/core/authorization/verify_project_write.py
@@ -2,6 +2,7 @@ from functools import wraps
 from http import HTTPStatus as status
 from typing import Any, Callable
 
+from keycloak import KeycloakError  # type: ignore
 from loguru import logger
 from sqlalchemy.exc import NoResultFound, SQLAlchemyError
 
@@ -55,6 +56,15 @@ def verify_project_write(f: Callable[..., Any]) -> Callable[..., Any]:
                 error_code=VliErrorCode.NOT_ALLOWED_OP,
                 http_status_code=status.FORBIDDEN,
                 message="The supplied authentication is not authorized for this action",
+            )
+        except KeycloakError as error:
+            logger.error(f"Keycloak error MESSAGE: {error.__str__}")
+            logger.exception(f"Keycloak get error {error}")
+            raise VliError(
+                error_code=VliErrorCode.INTERNAL_SERVER_ERROR,
+                http_status_code=status.BAD_REQUEST,
+                message="Checking for authorization failed",
+                details=error.__str__,
             )
         except Exception as error:
             logger.exception(f"Unknown error when checking for project_write: {error}")

--- a/virtual_labs/core/authorization/verify_vlab_or_project_read.py
+++ b/virtual_labs/core/authorization/verify_vlab_or_project_read.py
@@ -2,6 +2,7 @@ from functools import wraps
 from http import HTTPStatus as status
 from typing import Any, Callable
 
+from keycloak import KeycloakError  # type: ignore
 from loguru import logger
 from sqlalchemy.exc import NoResultFound, SQLAlchemyError
 
@@ -78,6 +79,15 @@ def verify_vlab_or_project_read(f: Callable[..., Any]) -> Callable[..., Any]:
                 error_code=VliErrorCode.NOT_ALLOWED_OP,
                 http_status_code=status.FORBIDDEN,
                 message="The supplied authentication is not authorized for this action",
+            )
+        except KeycloakError as error:
+            logger.error(f"Keycloak error MESSAGE: {error.__str__}")
+            logger.exception(f"Keycloak get error {error}")
+            raise VliError(
+                error_code=VliErrorCode.INTERNAL_SERVER_ERROR,
+                http_status_code=status.BAD_REQUEST,
+                message="Checking for authorization failed",
+                details=error.__str__,
             )
         except Exception as error:
             logger.exception("Unknown error when checking for authorization", error)

--- a/virtual_labs/core/authorization/verify_vlab_or_project_write.py
+++ b/virtual_labs/core/authorization/verify_vlab_or_project_write.py
@@ -2,6 +2,7 @@ from functools import wraps
 from http import HTTPStatus as status
 from typing import Any, Callable
 
+from keycloak import KeycloakError  # type: ignore
 from loguru import logger
 from sqlalchemy.exc import NoResultFound, SQLAlchemyError
 
@@ -74,6 +75,15 @@ def verify_vlab_or_project_write(f: Callable[..., Any]) -> Callable[..., Any]:
                 error_code=VliErrorCode.NOT_ALLOWED_OP,
                 http_status_code=status.FORBIDDEN,
                 message="The supplied authentication is not authorized for this action",
+            )
+        except KeycloakError as error:
+            logger.error(f"Keycloak error MESSAGE: {error.__str__}")
+            logger.exception(f"Keycloak get error {error}")
+            raise VliError(
+                error_code=VliErrorCode.INTERNAL_SERVER_ERROR,
+                http_status_code=status.BAD_REQUEST,
+                message="Checking for authorization failed",
+                details=error.__str__,
             )
         except Exception as error:
             logger.exception(


### PR DESCRIPTION
Unfortunately, the error thrown by Keycloak is swallowed by `python-keycloak` and converted to KeycloakError so, as far as I can tell, I cannot get the headers from this error.

I've added the logs in verify_jwt (that throws 401) and verify_vlab_read (that throws 403). There are other decorators that throw 403 too, but from what I've most of them are thrown when /users endpoint is called, so I only added in that one. Lemme know I should add them in all.