### PR TITLE
Log response body from keycloack since __str__ does not log it

### DIFF
--- a/virtual_labs/core/authorization/verify_project_read.py
+++ b/virtual_labs/core/authorization/verify_project_read.py
@@ -59,7 +59,9 @@ def verify_project_read(f: Callable[..., Any]) -> Callable[..., Any]:
                 message="The supplied authentication is not authorized for this action",
             )
         except KeycloakError as error:
-            logger.error(f"Keycloak error MESSAGE: {error.__str__}")
+            logger.error(
+                f"Keycloak error MESSAGE: {error.response_code} {error.response_body} {error.error_message}"
+            )
             logger.exception(f"Keycloak get error {error}")
             raise VliError(
                 error_code=VliErrorCode.INTERNAL_SERVER_ERROR,

--- a/virtual_labs/core/authorization/verify_project_write.py
+++ b/virtual_labs/core/authorization/verify_project_write.py
@@ -58,7 +58,9 @@ def verify_project_write(f: Callable[..., Any]) -> Callable[..., Any]:
                 message="The supplied authentication is not authorized for this action",
             )
         except KeycloakError as error:
-            logger.error(f"Keycloak error MESSAGE: {error.__str__}")
+            logger.error(
+                f"Keycloak error MESSAGE: {error.response_code} {error.response_body} {error.error_message}"
+            )
             logger.exception(f"Keycloak get error {error}")
             raise VliError(
                 error_code=VliErrorCode.INTERNAL_SERVER_ERROR,

--- a/virtual_labs/core/authorization/verify_vlab_or_project_read.py
+++ b/virtual_labs/core/authorization/verify_vlab_or_project_read.py
@@ -81,7 +81,9 @@ def verify_vlab_or_project_read(f: Callable[..., Any]) -> Callable[..., Any]:
                 message="The supplied authentication is not authorized for this action",
             )
         except KeycloakError as error:
-            logger.error(f"Keycloak error MESSAGE: {error.__str__}")
+            logger.error(
+                f"Keycloak error MESSAGE: {error.response_code} {error.response_body} {error.error_message}"
+            )
             logger.exception(f"Keycloak get error {error}")
             raise VliError(
                 error_code=VliErrorCode.INTERNAL_SERVER_ERROR,

--- a/virtual_labs/core/authorization/verify_vlab_or_project_write.py
+++ b/virtual_labs/core/authorization/verify_vlab_or_project_write.py
@@ -77,7 +77,9 @@ def verify_vlab_or_project_write(f: Callable[..., Any]) -> Callable[..., Any]:
                 message="The supplied authentication is not authorized for this action",
             )
         except KeycloakError as error:
-            logger.error(f"Keycloak error MESSAGE: {error.__str__}")
+            logger.error(
+                f"Keycloak error MESSAGE: {error.response_code} {error.response_body} {error.error_message}"
+            )
             logger.exception(f"Keycloak get error {error}")
             raise VliError(
                 error_code=VliErrorCode.INTERNAL_SERVER_ERROR,

--- a/virtual_labs/core/authorization/verify_vlab_read.py
+++ b/virtual_labs/core/authorization/verify_vlab_read.py
@@ -63,7 +63,9 @@ def verify_vlab_read(f: Callable[..., Any]) -> Callable[..., Any]:
                 message="The supplied authentication is not authorized for this action",
             )
         except KeycloakError as error:
-            logger.error(f"Keycloak error MESSAGE: {error.__str__}")
+            logger.error(
+                f"Keycloak error MESSAGE: {error.response_code} {error.response_body} {error.error_message}"
+            )
             logger.exception(f"Keycloak get error {error}")
             raise VliError(
                 error_code=VliErrorCode.INTERNAL_SERVER_ERROR,
@@ -72,7 +74,7 @@ def verify_vlab_read(f: Callable[..., Any]) -> Callable[..., Any]:
                 details=error.__str__,
             )
         except Exception as error:
-            logger.exception(f"Unknown error when checking for vlab_read: {error}")
+            logger.exception(f" : {error}")
             raise VliError(
                 error_code=VliErrorCode.INTERNAL_SERVER_ERROR,
                 http_status_code=status.BAD_REQUEST,

--- a/virtual_labs/core/authorization/verify_vlab_write.py
+++ b/virtual_labs/core/authorization/verify_vlab_write.py
@@ -60,7 +60,9 @@ def verify_vlab_write(f: Callable[..., Any]) -> Callable[..., Any]:
                 message="The supplied authentication is not authorized for this action",
             )
         except KeycloakError as error:
-            logger.error(f"Keycloak error MESSAGE: {error.__str__}")
+            logger.error(
+                f"Keycloak error MESSAGE: {error.response_code} {error.response_body} {error.error_message}"
+            )
             logger.exception(f"Keycloak get error {error}")
             raise VliError(
                 error_code=VliErrorCode.INTERNAL_SERVER_ERROR,


### PR DESCRIPTION
__str__ from KeycloakError class does not log response body so I'm logging it explicitly