### PR TITLE
BBPP134-2337 // Add endpoint to get or create agent api

### DIFF
--- a/env-prep/config/delta-postgres.conf
+++ b/env-prep/config/delta-postgres.conf
@@ -116,7 +116,7 @@ plugins {
     }
     suites = {
       sbo = [
-        "neurosciencegraph/datamodels"
+        "neurosciencegraph/datamodels",
       ]
     }
   }

--- a/env-prep/docker-compose-dev.yml
+++ b/env-prep/docker-compose-dev.yml
@@ -95,6 +95,7 @@ services:
       MP_SMTP_AUTH_ALLOW_INSECURE: 1
 
   delta:
+    container_name: delta
     depends_on:
       keycloak:
         condition: service_started

--- a/env-prep/init/bbp-agents-schemas/person_shape.json
+++ b/env-prep/init/bbp-agents-schemas/person_shape.json
@@ -1,0 +1,22 @@
+{
+    "@context": [
+      {
+        "this": "https://neuroshapes.org/dash/person/shapes/"
+      }
+    ],
+    "@id": "https://neuroshapes.org/dash/person",
+    "@type": "Schema",
+    "imports": [
+      "nsg:commons/person"
+    ],
+    "shapes": [
+      {
+        "@id": "https://neuroshapes.org/dash/person/shapes/PersonShape",
+        "@type": "NodeShape",
+        "label": "Schema.org person specification is used as a vocabulary to describe a person.",
+        "node": "nsg:commons/person/shapes/PersonShape",
+        "nodeKind": "sh:BlankNodeOrIRI",
+        "targetClass": "schema:Person"
+      }
+    ]
+}

--- a/virtual_labs/core/exceptions/nexus_error.py
+++ b/virtual_labs/core/exceptions/nexus_error.py
@@ -1,4 +1,5 @@
 from enum import StrEnum
+from http import HTTPStatus
 
 
 # TODO: NOTE: do we keep the suffix ERROR or not ?
@@ -30,18 +31,27 @@ class NexusErrorValue(StrEnum):
 
     CREATE_S3_STORAGE_ERROR = "NEXUS_CREATE_S3_STORAGE_ERROR"
 
+    GET_AGENT_ERROR = "NEXUS_GET_AGENT_ERROR"
+    CREATE_AGENT_ERROR = "CREATE_AGENT_ERROR"
+
     GENERIC_ERROR = "NEXUS_GENERIC_ERROR"
 
 
 class NexusError(Exception):
     message: str | None
     type: NexusErrorValue | None
+    http_status_code: HTTPStatus | None
 
     def __init__(
-        self, *, message: str | None = None, type: NexusErrorValue | None = None
+        self,
+        *,
+        message: str | None = None,
+        type: NexusErrorValue | None = None,
+        http_status_code: HTTPStatus | None = None,
     ) -> None:
         self.message = message
         self.type = type
+        self.http_status_code = http_status_code
         super().__init__(self.message)
 
     def __str__(self) -> str:

--- a/virtual_labs/domain/user.py
+++ b/virtual_labs/domain/user.py
@@ -52,3 +52,11 @@ class AllUsersCount(BaseModel):
 class UserWithInviteStatus(ShortenedUser):
     invite_accepted: bool
     role: UserRoleEnum
+
+
+class UserAgentResponse(BaseModel):
+    id: str
+    given_name: str
+    family_name: str
+    name: str
+    createdAt: datetime

--- a/virtual_labs/external/nexus/agent_interface.py
+++ b/virtual_labs/external/nexus/agent_interface.py
@@ -1,0 +1,95 @@
+from http import HTTPStatus
+from urllib.parse import quote_plus
+
+from httpx import AsyncClient
+from httpx._exceptions import HTTPStatusError
+from loguru import logger
+
+from virtual_labs.core.exceptions.nexus_error import NexusError, NexusErrorValue
+from virtual_labs.external.nexus.models import NexusBase, NexusUserAgent
+from virtual_labs.infrastructure.settings import settings
+
+
+class NexusAgentInterface:
+    httpx_client: AsyncClient
+    agent_org_project: str = "bbp/agents"
+    person_schema: str = "https://neuroshapes.org/dash/person"
+
+    def __init__(self, client: AsyncClient, client_token: str):
+        self.httpx_client = client
+        self.headers = {
+            "Content-Type": "application/json",
+            "Authorization": f"bearer {client_token}",
+        }
+
+    @classmethod
+    def get_agent_url(cls) -> str:
+        return f"{settings.NEXUS_DELTA_URI}/resources/{cls.agent_org_project}"
+
+    def __get_agent_id_from_username__(self, username: str) -> str:
+        return f"{settings.NEXUS_DELTA_URI}/realms/{settings.KC_REALM_NAME}/users/{username}"
+
+    async def retrieve_agent(
+        self,
+        agent_username: str,
+    ) -> NexusUserAgent:
+        agent_id = self.__get_agent_id_from_username__(username=agent_username)
+
+        try:
+            response = await self.httpx_client.get(
+                f"{self.get_agent_url()}/_/{quote_plus(agent_id)}", headers=self.headers
+            )
+            response.raise_for_status()
+            return NexusUserAgent.model_validate(response.json())
+        except HTTPStatusError as error:
+            logger.error(
+                f"HTTP Error when retrieving agent from nexus. Error {error}. Nexus Response: {response.json()}"
+            )
+            raise NexusError(
+                message=f"Could not retrieve agent from nexus. Nexus Response: {response.json()}",
+                type=NexusErrorValue.GET_AGENT_ERROR,
+                http_status_code=HTTPStatus(error.response.status_code),
+            )
+        except Exception as error:
+            logger.error(f"Could not retrieve agent from nexus. Exception {error}")
+            raise NexusError(
+                message=f"Could not retrieve agent from nexus. Nexus Response: {error}",
+                type=NexusErrorValue.GET_AGENT_ERROR,
+            )
+
+    async def create_agent(
+        self, username: str, first_name: str, last_name: str
+    ) -> NexusBase:
+        nexus_url = f"{self.get_agent_url()}/{quote_plus(self.person_schema)}"
+        try:
+            response = await self.httpx_client.post(
+                nexus_url,
+                headers=self.headers,
+                json={
+                    "@id": self.__get_agent_id_from_username__(username=username),
+                    "@type": ["Agent", "Person"],
+                    "familyName": last_name,
+                    "givenName": first_name,
+                    "name": f"{first_name} {last_name}",
+                    "@context": "https://bbp.neuroshapes.org",
+                },
+            )
+            response.raise_for_status()
+            return NexusBase.model_validate(response.json())
+        except HTTPStatusError as error:
+            logger.error(
+                f"HTTP Error when creating agent in nexus. Error {error}. Nexus Response: {response.json()}"
+            )
+            raise NexusError(
+                message=f"Could not create agent in nexus. Nexus Response: {response.json()}",
+                type=NexusErrorValue.GET_AGENT_ERROR,
+                http_status_code=HTTPStatus(error.response.status_code),
+            )
+        except Exception as error:
+            logger.exception(
+                f"Could not create agent. Error: {error}. Nexus Response: {response.json()}"
+            )
+            raise NexusError(
+                message=f"Could not create agent in nexus. Error {error}",
+                type=NexusErrorValue.CREATE_AGENT_ERROR,
+            )

--- a/virtual_labs/external/nexus/create_agent.py
+++ b/virtual_labs/external/nexus/create_agent.py
@@ -1,0 +1,16 @@
+import httpx
+
+from virtual_labs.external.nexus.agent_interface import NexusAgentInterface
+from virtual_labs.external.nexus.models import NexusBase
+from virtual_labs.infrastructure.kc.auth import get_client_token
+
+
+async def create_agent(username: str, first_name: str, last_name: str) -> NexusBase:
+    transport = httpx.AsyncHTTPTransport(retries=3)
+
+    async with httpx.AsyncClient(transport=transport, verify=False) as httpx_client:
+        client_token = get_client_token()
+        nexus_interface = NexusAgentInterface(httpx_client, client_token)
+        return await nexus_interface.create_agent(
+            username=username, first_name=first_name, last_name=last_name
+        )

--- a/virtual_labs/external/nexus/get_agent.py
+++ b/virtual_labs/external/nexus/get_agent.py
@@ -1,0 +1,14 @@
+import httpx
+
+from virtual_labs.external.nexus.agent_interface import NexusAgentInterface
+from virtual_labs.external.nexus.models import NexusUserAgent
+from virtual_labs.infrastructure.kc.auth import get_client_token
+
+
+async def get_agent(agent_username: str) -> NexusUserAgent:
+    transport = httpx.AsyncHTTPTransport(retries=3)
+
+    async with httpx.AsyncClient(transport=transport, verify=False) as httpx_client:
+        client_token = get_client_token()
+        nexus_interface = NexusAgentInterface(httpx_client, client_token)
+        return await nexus_interface.retrieve_agent(agent_username=agent_username)

--- a/virtual_labs/external/nexus/models.py
+++ b/virtual_labs/external/nexus/models.py
@@ -114,3 +114,9 @@ class ProjectView(TypedDict):
 
 class NexusS3Storage(NexusBase):
     type: Annotated[str | List[str], Field(alias="@type")] = ["Storage", "S3Storage"]
+
+
+class NexusUserAgent(NexusBase):
+    family_name: Annotated[str, Field(alias="familyName")]
+    given_name: Annotated[str, Field(alias="givenName")]
+    name: str

--- a/virtual_labs/infrastructure/kc/config.py
+++ b/virtual_labs/infrastructure/kc/config.py
@@ -1,11 +1,9 @@
-from keycloak import KeycloakOpenID  # type: ignore
-from keycloak import KeycloakAdmin
+from keycloak import KeycloakAdmin, KeycloakOpenID  # type: ignore
 
 from virtual_labs.infrastructure.settings import settings
 
 """
     will have many realms 
-    so for every realm we should configure another instance of connection
     or we should have service account and then use the credentials for every realm
     change realm_name depends on the user token for further ops
 """

--- a/virtual_labs/routes/common.py
+++ b/virtual_labs/routes/common.py
@@ -1,10 +1,13 @@
 from fastapi import APIRouter, Depends
 
 from virtual_labs.domain.labs import LabResponse
-from virtual_labs.domain.user import AllUsersCount
+from virtual_labs.domain.user import AllUsersCount, UserAgentResponse
 from virtual_labs.infrastructure.kc.auth import verify_jwt
 from virtual_labs.infrastructure.kc.models import AuthUser
 from virtual_labs.usecases.users.get_count_of_all_users import get_count_of_all_users
+from virtual_labs.usecases.users.get_or_create_user_agent import (
+    get_or_create_user_agent,
+)
 
 router = APIRouter()
 
@@ -14,3 +17,13 @@ async def get_all_users_count(
     auth: tuple[AuthUser, str] = Depends(verify_jwt),
 ) -> LabResponse[AllUsersCount]:
     return await get_count_of_all_users()
+
+
+@router.get("/agent", tags=["Agent"], response_model=LabResponse[UserAgentResponse])
+async def get_or_create_agent(
+    auth: tuple[AuthUser, str] = Depends(verify_jwt),
+) -> LabResponse[UserAgentResponse]:
+    """
+    Gets the "Agent" entity for the user calling the api (derived from the "Authorization" header). If the agent does not exist, a new one is created and returned.
+    """
+    return await get_or_create_user_agent(user=auth[0])

--- a/virtual_labs/shared/utils/name.py
+++ b/virtual_labs/shared/utils/name.py
@@ -1,0 +1,20 @@
+def extract_name_parts(name: str) -> tuple[str, str]:
+    """
+    Extracts the first name and last name from a given full name.
+
+    Args:
+        name (str): The full name of the person.
+
+    Returns:
+        tuple[str, str]: A tuple containing the first name and last name.
+                         If the name has only one word, the last name will be an empty string.
+    """
+    name_parts = name.strip().split(maxsplit=1)
+
+    if len(name_parts) == 1:
+        firstname = name_parts[0]
+        lastname = ""
+    else:
+        firstname, lastname = name_parts[0], name_parts[1]
+
+    return firstname, lastname

--- a/virtual_labs/tests/agent/test_get_agent.py
+++ b/virtual_labs/tests/agent/test_get_agent.py
@@ -1,0 +1,30 @@
+from http import HTTPStatus
+
+import pytest
+from httpx import AsyncClient
+from loguru import logger
+
+from virtual_labs.infrastructure.settings import settings
+from virtual_labs.tests.utils import get_headers
+
+
+@pytest.mark.asyncio
+async def test_get_agent(async_test_client: AsyncClient) -> None:
+    user = "test-2"
+    headers = get_headers(user)
+    response = await async_test_client.get("/agent", headers=headers)
+    assert response.status_code == HTTPStatus.OK
+
+    expected_agent_response = {
+        "id": f"{settings.NEXUS_DELTA_URI}/realms/{settings.KC_REALM_NAME}/users/{user}",
+        "given_name": user,
+        "family_name": user,
+        "name": f"{user} {user}",
+    }
+
+    gotten_agent_response = response.json()["data"]
+    logger.debug(f"Agent message {response.json()["message"]}")
+
+    assert gotten_agent_response["createdAt"] is not None
+    gotten_agent_response.pop("createdAt")
+    assert expected_agent_response == gotten_agent_response

--- a/virtual_labs/usecases/users/get_or_create_user_agent.py
+++ b/virtual_labs/usecases/users/get_or_create_user_agent.py
@@ -1,0 +1,74 @@
+from http import HTTPStatus
+
+from loguru import logger
+
+from virtual_labs.core.exceptions.api_error import VliError, VliErrorCode
+from virtual_labs.core.exceptions.nexus_error import NexusError
+from virtual_labs.domain.labs import LabResponse
+from virtual_labs.domain.user import UserAgentResponse
+from virtual_labs.external.nexus.create_agent import create_agent
+from virtual_labs.external.nexus.get_agent import get_agent
+from virtual_labs.infrastructure.kc.models import AuthUser
+from virtual_labs.shared.utils.name import extract_name_parts
+
+
+async def get_or_create_user_agent(user: AuthUser) -> LabResponse[UserAgentResponse]:
+    """
+    Fetches the agent information from nexus for the user passed in the user token.
+    If the nexus agent does not exist, one is created and returned.
+    """
+    try:
+        nexus_agent = await get_agent(agent_username=user.username)
+        return LabResponse(
+            message="Agent successfully fetched",
+            data=UserAgentResponse.model_validate(nexus_agent.model_dump()),
+        )
+    except NexusError as nexus_error:
+        if nexus_error.http_status_code == HTTPStatus.NOT_FOUND:
+            try:
+                logger.debug("Agent for user not found. About to create one.")
+                (firstname, lastname) = extract_name_parts(user.name)
+                await create_agent(
+                    username=user.username, first_name=firstname, last_name=lastname
+                )
+                created_agent = await get_agent(agent_username=user.username)
+                return LabResponse(
+                    message="Agent successfully created",
+                    data=UserAgentResponse.model_validate(created_agent.model_dump()),
+                )
+            except NexusError as err:
+                raise VliError(
+                    message="Creating agent on nexus failed",
+                    details=f"{err}",
+                    error_code=VliErrorCode.EXTERNAL_SERVICE_ERROR,
+                    http_status_code=err.http_status_code
+                    if err.http_status_code is not None
+                    else HTTPStatus.BAD_GATEWAY,
+                )
+            except Exception as err:
+                logger.exception(f"Unknown error occured when creating agent {err}")
+                raise VliError(
+                    message="Creating agent on nexus failed due to an unknown error",
+                    details=f"{err}",
+                    error_code=VliErrorCode.INTERNAL_SERVER_ERROR,
+                    http_status_code=HTTPStatus.INTERNAL_SERVER_ERROR,
+                )
+        else:
+            raise VliError(
+                message="Unknown nexus error when retrieving agent",
+                details=f"{nexus_error}",
+                error_code=VliErrorCode.EXTERNAL_SERVICE_ERROR,
+                http_status_code=nexus_error.http_status_code
+                if nexus_error.http_status_code is not None
+                else HTTPStatus.BAD_GATEWAY,
+            )
+    except VliError as verr:
+        raise verr
+    except Exception as error:
+        logger.exception(f"Unknown error when retrieving agent from nexus {error}")
+        raise VliError(
+            message="Unknown error when retrieving agent from nexus",
+            details=f"{error}",
+            error_code=VliErrorCode.INTERNAL_SERVER_ERROR,
+            http_status_code=HTTPStatus.INTERNAL_SERVER_ERROR,
+        )


### PR DESCRIPTION
Implements [BBPP134-2337](https://bbpteam.epfl.ch/project/issues/browse/BBPP134-2337)


While working on this ticket I also realized that we use httpx client to communicate with nexus instead of the `requests` module from python. Since fastapi already takes care of making the fastapi server concurrent and we don't need more finer grained concurrency per request handler, I think, if we ever revisit this in the future, we can get rid of it in favour of the simpler `requests` package.